### PR TITLE
Fix libusb_exit() on Windows

### DIFF
--- a/include/astra_device_manager.hpp
+++ b/include/astra_device_manager.hpp
@@ -12,7 +12,7 @@
 #include "flash_image.hpp"
 #include "astra_log.hpp"
 
-#define ASTRA_DEVICE_MANAGER_VERSION "1.0.1"
+#define ASTRA_DEVICE_MANAGER_VERSION "1.0.2"
 
 enum AstraDeviceManagerStatus {
     ASTRA_DEVICE_MANAGER_STATUS_START,

--- a/lib/win_usb_transport.cpp
+++ b/lib/win_usb_transport.cpp
@@ -61,10 +61,6 @@ void WinUSBTransport::Shutdown()
         if (m_deviceMonitorThread.joinable()) {
             m_deviceMonitorThread.join();
         }
-
-        if (m_ctx) {
-            libusb_exit(m_ctx);
-        }
     }
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ ExternalProject_Add(cxxopts
 
 ExternalProject_Add(indicators
     GIT_REPOSITORY https://github.com/p-ranav/indicators.git
-    GIT_TAG master
+    GIT_TAG ac6c93ea2b1f97a220d10a0729a625b3f51e320b
     PREFIX ${CMAKE_BINARY_DIR}/indicators
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/indicators
                -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}

--- a/src/astra-boot.cpp
+++ b/src/astra-boot.cpp
@@ -16,7 +16,7 @@
 #include "flash_image.hpp"
 #include "astra_device.hpp"
 
-const std::string astraBootVersion = "1.0.1";
+const std::string astraBootVersion = "1.0.2";
 
 // Define a struct to hold the two strings
 struct DeviceImageKey {

--- a/src/astra-update.cpp
+++ b/src/astra-update.cpp
@@ -16,7 +16,7 @@
 #include "flash_image.hpp"
 #include "astra_device.hpp"
 
-const std::string astraUpdateVersion = "1.0.1";
+const std::string astraUpdateVersion = "1.0.2";
 
 // Define a struct to hold the two strings
 struct DeviceImageKey {


### PR DESCRIPTION
- **Use a specific commit of the indicator library instead of just pulling from master**
- **Remove libusb_exit() from WinUSBTransport::Shutdown()**
