### PR TITLE
Support Multiple Instances of AstraDeviceManager

### DIFF
--- a/lib/astra_device_manager.cpp
+++ b/lib/astra_device_manager.cpp
@@ -47,6 +47,8 @@ public:
         AstraLogStore::getInstance().Open(m_modifiedLogPath, minLogLevel);
 
         ASTRA_LOG;
+
+        log(ASTRA_LOG_LEVEL_INFO) << "astra-update v" << AstraDeviceManager::GetVersion() << endLog;
     }
 
     void Update(std::shared_ptr<FlashImage> flashImage, std::string bootImagesPath)

--- a/lib/astra_log.cpp
+++ b/lib/astra_log.cpp
@@ -115,7 +115,7 @@ void AstraLogStore::Open(const std::string &logPath, AstraLogLevel minLogLevel) 
     if (logPath == "" || logPath == "stdout") {
         m_logStream = std::make_unique<std::ostream>(std::cout.rdbuf());
     } else {
-        m_logFile.open(logPath, std::ios::out | std::ios::trunc);
+        m_logFile.open(logPath, std::ios::out | std::ios::app);
         if (!m_logFile.is_open()) {
             throw std::runtime_error("Failed to open log file");
         }

--- a/lib/win_usb_transport.cpp
+++ b/lib/win_usb_transport.cpp
@@ -55,6 +55,7 @@ void WinUSBTransport::Shutdown()
                 m_hotplugThread.join();
             }
             DestroyWindow(m_hWnd);
+            UnregisterClass(TEXT("AstraDeviceManager"), GetModuleHandle(nullptr));
             m_hWnd = nullptr;
         }
 


### PR DESCRIPTION
- **Call UnregisterClass() during shutdown to allow registering later**
- **Open the device manager log as append to support more then instance of AstraDeviceManager**
- **Print the astra-update library version to the log file**
