### PR TITLE
Coralboard and SPI Flash Improvements

### DIFF
--- a/include/astra_device_manager.hpp
+++ b/include/astra_device_manager.hpp
@@ -12,7 +12,7 @@
 #include "flash_image.hpp"
 #include "astra_log.hpp"
 
-#define ASTRA_DEVICE_MANAGER_VERSION "2.0.1-prerelease"
+#define ASTRA_DEVICE_MANAGER_VERSION "2.0.1"
 
 enum AstraDeviceManagerStatus {
     ASTRA_DEVICE_MANAGER_STATUS_START,

--- a/include/astra_device_manager.hpp
+++ b/include/astra_device_manager.hpp
@@ -12,7 +12,7 @@
 #include "flash_image.hpp"
 #include "astra_log.hpp"
 
-#define ASTRA_DEVICE_MANAGER_VERSION "2.0.0"
+#define ASTRA_DEVICE_MANAGER_VERSION "2.0.1-prerelease"
 
 enum AstraDeviceManagerStatus {
     ASTRA_DEVICE_MANAGER_STATUS_START,

--- a/include/flash_image.hpp
+++ b/include/flash_image.hpp
@@ -63,8 +63,10 @@ protected:
 
 struct ChipDetectionResult {
     std::string chipName;
+    std::string boardName;
     AstraSecureBootVersion secureBootVersion = ASTRA_SECURE_BOOT_V3;
     AstraMemoryLayout memoryLayout = ASTRA_MEMORY_LAYOUT_2GB;
+    AstraMemoryDDRType memoryDDRType = ASTRA_MEMORY_DDR_TYPE_NOT_SPECIFIED;
     bool found = false;
 };
 

--- a/lib/boot_image_collection.cpp
+++ b/lib/boot_image_collection.cpp
@@ -75,33 +75,46 @@ std::vector<std::shared_ptr<AstraBootImage>> BootImageCollection::GetBootImagesF
 {
     ASTRA_LOG;
 
+    // For SL261x variants (where x > 0), collect candidate chip names: exact match first, then series fallback.
+    std::vector<std::string> chipNamesToTry = { chipName };
+    if (chipName.size() == 6 && chipName.compare(0, 5, "sl261") == 0 && chipName[5] > '0') {
+        chipNamesToTry.push_back("sl2610");
+    }
+
     std::vector<std::shared_ptr<AstraBootImage>> bootImages;
 
-    for (const auto& bootImage : m_bootImages) {
-        if (bootImage->GetChipName() == chipName && bootImage->GetSecureBootVersion() == secureBoot
-          && bootImage->GetMemoryLayout() == memoryLayout)
-        {
-            bool boardImageMatch = false;
+    for (const auto& candidateChipName : chipNamesToTry) {
+        for (const auto& bootImage : m_bootImages) {
+            if (bootImage->GetChipName() == candidateChipName && bootImage->GetSecureBootVersion() == secureBoot
+              && bootImage->GetMemoryLayout() == memoryLayout)
+            {
+                bool boardImageMatch = false;
 
-             if (boardName.empty()) {
-                boardImageMatch = true;
-            } else if (bootImage->GetBoardName() == boardName) {
-                boardImageMatch = true;
-            }
+                if (boardName.empty()) {
+                    boardImageMatch = true;
+                } else if (bootImage->GetBoardName() == boardName) {
+                    boardImageMatch = true;
+                }
 
-            // If DDR Type is not set to a specific value then do
-            // not use it for matching.
-            if (memoryDDRType == ASTRA_MEMORY_DDR_TYPE_NOT_SPECIFIED) {
-                boardImageMatch = true;
-            } else if (bootImage->GetMemoryDDRType() == memoryDDRType) {
-                boardImageMatch = true;
-            } else {
-                boardImageMatch = false;
-            }
+                // If DDR Type is not set to a specific value then do
+                // not use it for matching.
+                if (memoryDDRType == ASTRA_MEMORY_DDR_TYPE_NOT_SPECIFIED) {
+                    boardImageMatch = true;
+                } else if (bootImage->GetMemoryDDRType() == memoryDDRType) {
+                    boardImageMatch = true;
+                } else {
+                    boardImageMatch = false;
+                }
 
-            if (boardImageMatch) {
-                bootImages.push_back(bootImage);
+                if (boardImageMatch) {
+                    bootImages.push_back(bootImage);
+                }
             }
+        }
+
+        // If we found matches with the exact chip name, do not try the series fallback.
+        if (!bootImages.empty()) {
+            break;
         }
     }
 

--- a/lib/emmc_flash_image.cpp
+++ b/lib/emmc_flash_image.cpp
@@ -48,6 +48,7 @@ int EmmcFlashImage::Load()
                 m_chipName = detection.chipName;
                 m_secureBootVersion = detection.secureBootVersion;
                 m_memoryLayout = detection.memoryLayout;
+                m_memoryDDRType = detection.memoryDDRType;
             }
         } catch (const std::exception& e) {
             log(ASTRA_LOG_LEVEL_WARNING) << "Failed to detect chip from TAG file: " << e.what() << endLog;

--- a/lib/flash_image.cpp
+++ b/lib/flash_image.cpp
@@ -179,6 +179,13 @@ std::shared_ptr<FlashImage> FlashImage::FlashImageFactory(std::string imagePath,
         memoryDDRType = ASTRA_MEMORY_DDR_TYPE_DDR4X16;
     }
 
+    // Set board-specific DDR type defaults when not explicitly configured
+    if (memoryDDRType == ASTRA_MEMORY_DDR_TYPE_NOT_SPECIFIED) {
+        if (boardName == "coralboard") {
+            memoryDDRType = ASTRA_MEMORY_DDR_TYPE_DDR4X16;
+        }
+    }
+
     if (flashImageType == FLASH_IMAGE_TYPE_UNKNOWN) {
         if (std::filesystem::exists(imagePath) && std::filesystem::is_directory(imagePath)) {
             // Check for NAND image by looking for a Yocto TAG file containing "nand"
@@ -254,10 +261,20 @@ ChipDetectionResult DetectChipFromTagFile(const std::string& imagePath, const st
                         continue;
                     }
 
+                    // Extract board name from the part of the filename after the chip name.
+                    // e.g. TAG--astra-media-sl2619-coralboard.rootfs-... -> "coralboard"
+                    std::size_t boardPos = pos + 6;
+                    if (boardPos < filename.size() && filename[boardPos] == '-') {
+                        std::string boardRemainder = filename.substr(boardPos + 1);
+                        std::size_t dotPos = boardRemainder.find('.');
+                        result.boardName = boardRemainder.substr(0, dotPos);
+                    }
+
                     if (potentialChipName == "sl1680") {
                         result.chipName = potentialChipName;
                         result.secureBootVersion = ASTRA_SECURE_BOOT_V3;
                         result.memoryLayout = ASTRA_MEMORY_LAYOUT_4GB;
+                        result.memoryDDRType = ASTRA_MEMORY_DDR_TYPE_LPDDR4X;
                         result.found = true;
                         log(ASTRA_LOG_LEVEL_INFO) << "Detected image is for chip: " << result.chipName << endLog;
                     }
@@ -265,6 +282,7 @@ ChipDetectionResult DetectChipFromTagFile(const std::string& imagePath, const st
                         result.chipName = potentialChipName;
                         result.secureBootVersion = ASTRA_SECURE_BOOT_V3;
                         result.memoryLayout = ASTRA_MEMORY_LAYOUT_2GB;
+                        result.memoryDDRType = ASTRA_MEMORY_DDR_TYPE_LPDDR4;
                         result.found = true;
                         log(ASTRA_LOG_LEVEL_INFO) << "Detected image is for chip: " << result.chipName << endLog;
                     }
@@ -272,13 +290,20 @@ ChipDetectionResult DetectChipFromTagFile(const std::string& imagePath, const st
                         result.chipName = potentialChipName;
                         result.secureBootVersion = ASTRA_SECURE_BOOT_V3;
                         result.memoryLayout = ASTRA_MEMORY_LAYOUT_2GB;
+                        result.memoryDDRType = ASTRA_MEMORY_DDR_TYPE_DDR4;
                         result.found = true;
                         log(ASTRA_LOG_LEVEL_INFO) << "Detected image is for chip: " << result.chipName << endLog;
                     }
                     else if (potentialChipName.compare(0, 5, "sl261") == 0) {
-                        result.chipName = "sl2610";
+                        result.chipName = potentialChipName;
                         result.secureBootVersion = ASTRA_SECURE_BOOT_V3;
                         result.memoryLayout = ASTRA_MEMORY_LAYOUT_2GB;
+                        // Set board-specific DDR type defaults
+                        if (result.boardName == "coralboard") {
+                            result.memoryDDRType = ASTRA_MEMORY_DDR_TYPE_DDR4X16;
+                        } else {
+                            result.memoryDDRType = ASTRA_MEMORY_DDR_TYPE_DDR4X16;
+                        }
                         result.found = true;
                         log(ASTRA_LOG_LEVEL_INFO) << "Detected image is for chip: " << result.chipName << endLog;
                     }

--- a/lib/flash_image.cpp
+++ b/lib/flash_image.cpp
@@ -302,7 +302,7 @@ ChipDetectionResult DetectChipFromTagFile(const std::string& imagePath, const st
                         if (result.boardName == "coralboard") {
                             result.memoryDDRType = ASTRA_MEMORY_DDR_TYPE_DDR4X16;
                         } else {
-                            result.memoryDDRType = ASTRA_MEMORY_DDR_TYPE_DDR4X16;
+                            result.memoryDDRType = ASTRA_MEMORY_DDR_TYPE_DDR4;
                         }
                         result.found = true;
                         log(ASTRA_LOG_LEVEL_INFO) << "Detected image is for chip: " << result.chipName << endLog;

--- a/lib/nand_flash_image.cpp
+++ b/lib/nand_flash_image.cpp
@@ -70,6 +70,7 @@ int NandFlashImage::Load()
                 m_chipName = detection.chipName;
                 m_secureBootVersion = detection.secureBootVersion;
                 m_memoryLayout = detection.memoryLayout;
+                m_memoryDDRType = detection.memoryDDRType;
             }
         } catch (const std::exception& e) {
             log(ASTRA_LOG_LEVEL_WARNING) << "Failed to detect chip from TAG file: " << e.what() << endLog;

--- a/lib/spi_flash_image.cpp
+++ b/lib/spi_flash_image.cpp
@@ -110,7 +110,8 @@ int SpiFlashImage::Load()
         log(ASTRA_LOG_LEVEL_DEBUG) << "Using SL2610 SPI flash command sequence" << endLog;
         for (const auto &imageConfig : m_spiImageConfigs) {
              m_flashCommand += "usbload "  + imageConfig.imageFile + " " + imageConfig.readAddress + "; sf probe; sf erase " + imageConfig.eraseFirstStartAddress + " " + imageConfig.eraseFirstLength
-                + "; sf write " + imageConfig.readAddress + " " + imageConfig.writeFirstCopyAddress + " " + imageConfig.writeLength;
+                + "; sf write " + imageConfig.readAddress + " " + imageConfig.writeFirstCopyAddress + " " + imageConfig.writeLength + "; sf erase " + imageConfig.eraseSecondStartAddress
+                + " " + imageConfig.eraseSecondLength + "; sf write " + imageConfig.readAddress + " " + imageConfig.writeSecondCopyAddress + " " + imageConfig.writeLength + "; ";
         }
         log(ASTRA_LOG_LEVEL_DEBUG) << "Copy flash command: " << m_flashCommand << endLog;
     } else {

--- a/lib/spi_flash_image.hpp
+++ b/lib/spi_flash_image.hpp
@@ -26,9 +26,12 @@ private:
                 // Overwrite default config values for SL2610 series.
                 readAddress = "0x10000000";
                 writeFirstCopyAddress = "0";
-                writeLength = "0x200000";
+                writeSecondCopyAddress = "0x200000";
+                writeLength = "$filesize";
                 eraseFirstStartAddress = "0";
                 eraseFirstLength = "0x200000";
+                eraseSecondStartAddress = "0x200000";
+                eraseSecondLength = "0x200000";
             }
         }
         std::string imageFile;

--- a/src/astra-boot.cpp
+++ b/src/astra-boot.cpp
@@ -16,7 +16,7 @@
 #include "flash_image.hpp"
 #include "astra_device.hpp"
 
-const std::string astraBootVersion = "2.0.0";
+const std::string astraBootVersion = "2.0.1";
 
 // Define a struct to hold the two strings
 struct DeviceImageKey {

--- a/src/astra-update.cpp
+++ b/src/astra-update.cpp
@@ -16,7 +16,7 @@
 #include "flash_image.hpp"
 #include "astra_device.hpp"
 
-const std::string astraUpdateVersion = "2.0.0";
+const std::string astraUpdateVersion = "2.0.1";
 
 // Define a struct to hold the two strings
 struct DeviceImageKey {


### PR DESCRIPTION
- **Add support for writing SPI images to the second slot**
- **Detect coarlboard images using the Yocto TAG file and set default DDR types**
